### PR TITLE
adding GeoAddressLocationBuilder

### DIFF
--- a/results.json
+++ b/results.json
@@ -1,6 +1,6 @@
 [
 	{
-		"address": "777 Brockton Avenue, Abington MA 2351",
+		"address": "777 Brockton Ave, Abington, MA 02351, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -70.9686115,
@@ -8,7 +8,7 @@
 		}
 	},
 	{
-		"address": "30 Memorial Drive, Avon MA 2322",
+		"address": "30 Memorial Dr, Avon, MA 02322, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.0300905,
@@ -16,7 +16,7 @@
 		}
 	},
 	{
-		"address": "250 Hartford Avenue, Bellingham MA 2019",
+		"address": "250 Hartford Ave, Bellingham, MA 02019, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.46537099999999,
@@ -24,7 +24,7 @@
 		}
 	},
 	{
-		"address": "700 Oak Street, Brockton MA 2301",
+		"address": "700 Oak St, Brockton, MA 02301, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.0572882,
@@ -32,7 +32,7 @@
 		}
 	},
 	{
-		"address": "66-4 Parkhurst Rd, Chelmsford MA 1824",
+		"address": "4 Parkhurst Rd, Chelmsford, MA 01824, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.3636262,
@@ -40,7 +40,7 @@
 		}
 	},
 	{
-		"address": "591 Memorial Dr, Chicopee MA 1020",
+		"address": "591 Memorial Dr, Chicopee, MA 01020, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.5738274,
@@ -48,7 +48,7 @@
 		}
 	},
 	{
-		"address": "55 Brooksby Village Way, Danvers MA 1923",
+		"address": "55 Brooksby Village Dr, Danvers, MA 01923, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -70.96824,
@@ -56,7 +56,7 @@
 		}
 	},
 	{
-		"address": "137 Teaticket Hwy, East Falmouth MA 2536",
+		"address": "137 Teaticket Hwy, Teaticket, MA 02536, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -70.5939806,
@@ -64,7 +64,7 @@
 		}
 	},
 	{
-		"address": "42 Fairhaven Commons Way, Fairhaven MA 2719",
+		"address": "42 Fairhaven Commons Way, Fairhaven, MA 02719, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -70.8879561,
@@ -72,7 +72,7 @@
 		}
 	},
 	{
-		"address": "374 William S Canning Blvd, Fall River MA 2721",
+		"address": "374 William S Canning Blvd, Fall River, MA 02721, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.15865889999999,
@@ -80,7 +80,7 @@
 		}
 	},
 	{
-		"address": "121 Worcester Rd, Framingham MA 1701",
+		"address": "121 Worcester Rd, Framingham, MA 01701, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.39969359999999,
@@ -88,7 +88,7 @@
 		}
 	},
 	{
-		"address": "677 Timpany Blvd, Gardner MA 1440",
+		"address": "677 Timpany Blvd, Gardner, MA 01440, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.99477639999999,
@@ -96,7 +96,7 @@
 		}
 	},
 	{
-		"address": "337 Russell St, Hadley MA 1035",
+		"address": "337 Russell St, Hadley, MA 01035, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.5524104,
@@ -104,7 +104,7 @@
 		}
 	},
 	{
-		"address": "295 Plymouth Street, Halifax MA 2338",
+		"address": "295 Plymouth St, Halifax, MA 02338, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -70.8463701,
@@ -112,7 +112,7 @@
 		}
 	},
 	{
-		"address": "1775 Washington St, Hanover MA 2339",
+		"address": "1775 Washington St, Hanover, MA 02339, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -70.8420967,
@@ -120,7 +120,7 @@
 		}
 	},
 	{
-		"address": "280 Washington Street, Hudson MA 1749",
+		"address": "280 Washington St, Hudson, MA 01749, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.5588568,
@@ -128,7 +128,7 @@
 		}
 	},
 	{
-		"address": "20 Soojian Dr, Leicester MA 1524",
+		"address": "20 Soojian Dr, Leicester, MA 01524, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.9351624,
@@ -136,7 +136,7 @@
 		}
 	},
 	{
-		"address": "11 Jungle Road, Leominster MA 1453",
+		"address": "11 Jungle Rd, Leominster, MA 01453, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.7296017,
@@ -144,7 +144,7 @@
 		}
 	},
 	{
-		"address": "301 Massachusetts Ave, Lunenburg MA 1462",
+		"address": "301 Massachusetts Ave, Lunenburg, MA 01462, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.7598385,
@@ -152,7 +152,7 @@
 		}
 	},
 	{
-		"address": "780 Lynnway, Lynn MA 1905",
+		"address": "780 Lynnway, Lynn, MA 01905, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -70.9608099,
@@ -160,7 +160,7 @@
 		}
 	},
 	{
-		"address": "70 Pleasant Valley Street, Methuen MA 1844",
+		"address": "70 Pleasant Valley St, Methuen, MA 01844, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.1654606,
@@ -168,7 +168,7 @@
 		}
 	},
 	{
-		"address": "830 Curran Memorial Hwy, North Adams MA 1247",
+		"address": "1600 Curran Hwy, North Adams, MA 01247, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.1088364,
@@ -176,7 +176,7 @@
 		}
 	},
 	{
-		"address": "1470 S Washington St, North Attleboro MA 2760",
+		"address": "1470 S Washington St, North Attleborough, MA 02760, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.35014939999999,
@@ -184,7 +184,7 @@
 		}
 	},
 	{
-		"address": "506 State Road, North Dartmouth MA 2747",
+		"address": "506 State Rd, North Dartmouth, MA 02747, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.00791079999999,
@@ -192,7 +192,7 @@
 		}
 	},
 	{
-		"address": "742 Main Street, North Oxford MA 1537",
+		"address": "742 Main St, North Oxford, MA 01537, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.8789377,
@@ -200,7 +200,7 @@
 		}
 	},
 	{
-		"address": "72 Main St, North Reading MA 1864",
+		"address": "72 Main St, North Reading, MA 01864, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.11272919999999,
@@ -208,7 +208,7 @@
 		}
 	},
 	{
-		"address": "200 Otis Street, Northborough MA 1532",
+		"address": "200 Otis St, Northborough, MA 01532, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.6563963,
@@ -216,7 +216,7 @@
 		}
 	},
 	{
-		"address": "180 North King Street, Northhampton MA 1060",
+		"address": "180 N King St, Northampton, MA 01060, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.643759,
@@ -224,7 +224,7 @@
 		}
 	},
 	{
-		"address": "555 East Main St, Orange MA 1364",
+		"address": "555 E Main St, Orange, MA 01364, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.2842989,
@@ -232,7 +232,7 @@
 		}
 	},
 	{
-		"address": "555 Hubbard Ave-Suite 12, Pittsfield MA 1201",
+		"address": "555 Hubbard Ave #12, Pittsfield, MA 01201, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.1977536,
@@ -240,7 +240,7 @@
 		}
 	},
 	{
-		"address": "300 Colony Place, Plymouth MA 2360",
+		"address": "300 Colony Pl, Plymouth, MA 02360, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -70.718142,
@@ -248,7 +248,7 @@
 		}
 	},
 	{
-		"address": "301 Falls Blvd, Quincy MA 2169",
+		"address": "301 Falls Blvd, Quincy, MA 02169, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -70.9864432,
@@ -256,7 +256,7 @@
 		}
 	},
 	{
-		"address": "36 Paramount Drive, Raynham MA 2767",
+		"address": "36 Paramount Dr, Raynham, MA 02767, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.0323192,
@@ -264,7 +264,7 @@
 		}
 	},
 	{
-		"address": "450 Highland Ave, Salem MA 1970",
+		"address": "450 Highland Ave, Salem, MA 01970, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -70.93557930000001,
@@ -272,7 +272,7 @@
 		}
 	},
 	{
-		"address": "1180 Fall River Avenue, Seekonk MA 2771",
+		"address": "1180 Fall River Ave, Seekonk, MA 02771, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.3254984,
@@ -280,7 +280,7 @@
 		}
 	},
 	{
-		"address": "1105 Boston Road, Springfield MA 1119",
+		"address": "1105 Boston Rd, Springfield, MA 01119, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.5069872,
@@ -288,7 +288,7 @@
 		}
 	},
 	{
-		"address": "100 Charlton Road, Sturbridge MA 1566",
+		"address": "100 Charlton Rd, Sturbridge, MA 01566, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.05912289999999,
@@ -296,7 +296,7 @@
 		}
 	},
 	{
-		"address": "262 Swansea Mall Dr, Swansea MA 2777",
+		"address": "262 Swansea Mall Dr, Swansea, MA 02777, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.2179992,
@@ -304,7 +304,7 @@
 		}
 	},
 	{
-		"address": "333 Main Street, Tewksbury MA 1876",
+		"address": "333 Main St, Tewksbury, MA 01876, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.2686442,
@@ -312,7 +312,7 @@
 		}
 	},
 	{
-		"address": "550 Providence Hwy, Walpole MA 2081",
+		"address": "550 Providence Hwy, Walpole, MA 02081, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.2144721,
@@ -320,7 +320,7 @@
 		}
 	},
 	{
-		"address": "352 Palmer Road, Ware MA 1082",
+		"address": "352 Palmer Rd, Ware, MA 01082, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.2787543,
@@ -328,7 +328,7 @@
 		}
 	},
 	{
-		"address": "3005 Cranberry Hwy Rt 6 28, Wareham MA 2538",
+		"address": "3005 Cranberry Hwy, East Wareham, MA 02538, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -70.6633411,
@@ -336,7 +336,7 @@
 		}
 	},
 	{
-		"address": "250 Rt 59, Airmont NY 10901",
+		"address": "250 W Rte 59, Spring Valley, NY 10977, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -74.0478979,
@@ -344,7 +344,7 @@
 		}
 	},
 	{
-		"address": "141 Washington Ave Extension, Albany NY 12205",
+		"address": "141 Washington Ave Ext, Albany, NY 12205, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.8461142,
@@ -352,7 +352,7 @@
 		}
 	},
 	{
-		"address": "13858 Rt 31 W, Albion NY 14411",
+		"address": "13858 NY-31, Albion, NY 14411, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -78.2258973,
@@ -360,7 +360,7 @@
 		}
 	},
 	{
-		"address": "2055 Niagara Falls Blvd, Amherst NY 14228",
+		"address": "2055 Niagara Falls Blvd, Buffalo, NY 14228, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -78.8186202,
@@ -368,7 +368,7 @@
 		}
 	},
 	{
-		"address": "101 Sanford Farm Shpg Center, Amsterdam NY 12010",
+		"address": "101 Sanford farms shopping Center, Amsterdam, NY 12010, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -74.1836972,
@@ -376,7 +376,7 @@
 		}
 	},
 	{
-		"address": "297 Grant Avenue, Auburn NY 13021",
+		"address": "297 Grant Ave, Auburn, NY 13021, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -76.5481875,
@@ -384,7 +384,7 @@
 		}
 	},
 	{
-		"address": "4133 Veterans Memorial Drive, Batavia NY 14020",
+		"address": "4133 Veterans Memorial Dr, Batavia, NY 14020, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -78.20791489999999,
@@ -392,7 +392,7 @@
 		}
 	},
 	{
-		"address": "6265 Brockport Spencerport Rd, Brockport NY 14420",
+		"address": "6265 Brockport Spencerport Rd, Brockport, NY 14420, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -77.9278119,
@@ -400,7 +400,7 @@
 		}
 	},
 	{
-		"address": "5399 W Genesse St, Camillus NY 13031",
+		"address": "5399 W Genesee St, Camillus, NY 13031, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -76.27301600000001,
@@ -408,7 +408,7 @@
 		}
 	},
 	{
-		"address": "3191 County rd 10, Canandaigua NY 14424",
+		"address": "3191 Co Rd 10, Canandaigua, NY 14424, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -77.24310129999999,
@@ -416,7 +416,7 @@
 		}
 	},
 	{
-		"address": "30 Catskill, Catskill NY 12414",
+		"address": "30 Catskill Commons, Catskill, NY 12414, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.88288630000001,
@@ -424,7 +424,7 @@
 		}
 	},
 	{
-		"address": "161 Centereach Mall, Centereach NY 11720",
+		"address": "161 Centereach Mall, Centereach, NY 11720, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.0812935,
@@ -432,7 +432,7 @@
 		}
 	},
 	{
-		"address": "3018 East Ave, Central Square NY 13036",
+		"address": "3018 East Ave, Central Square, NY 13036, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -76.1273069,
@@ -440,7 +440,7 @@
 		}
 	},
 	{
-		"address": "100 Thruway Plaza, Cheektowaga NY 14225",
+		"address": "100 Thruway Plaza Dr, Cheektowaga, NY 14225, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -78.7782577,
@@ -448,7 +448,7 @@
 		}
 	},
 	{
-		"address": "8064 Brewerton Rd, Cicero NY 13039",
+		"address": "8064 Brewerton Rd, Cicero, NY 13039, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -76.1175252,
@@ -456,7 +456,7 @@
 		}
 	},
 	{
-		"address": "5033 Transit Road, Clarence NY 14031",
+		"address": "5033 Transit Rd, Williamsville, NY 14221, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -78.693939,
@@ -464,7 +464,7 @@
 		}
 	},
 	{
-		"address": "3949 Route 31, Clay NY 13041",
+		"address": "3949 NY-31, Liverpool, NY 13090, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -76.2401941,
@@ -472,7 +472,7 @@
 		}
 	},
 	{
-		"address": "139 Merchant Place, Cobleskill NY 12043",
+		"address": "139 Merchant Pl, Cobleskill, NY 12043, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -74.4553104,
@@ -480,7 +480,7 @@
 		}
 	},
 	{
-		"address": "85 Crooked Hill Road, Commack NY 11725",
+		"address": "85 Crooked Hill Rd, Commack, NY 11725, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.2894357,
@@ -488,7 +488,7 @@
 		}
 	},
 	{
-		"address": "872 Route 13, Cortlandville NY 13045",
+		"address": "872 NY-13, Cortland, NY 13045, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -76.214716,
@@ -496,7 +496,7 @@
 		}
 	},
 	{
-		"address": "279 Troy Road, East Greenbush NY 12061",
+		"address": "279 Troy Rd, East Greenbush, NY 12061, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.7014453,
@@ -504,7 +504,7 @@
 		}
 	},
 	{
-		"address": "2465 Hempstead Turnpike, East Meadow NY 11554",
+		"address": "2465 Hempstead Turnpike, East Meadow, NY 11554, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.5437687,
@@ -512,7 +512,7 @@
 		}
 	},
 	{
-		"address": "6438 Basile Rowe, East Syracuse NY 13057",
+		"address": "6438 Basile Rowe, East Syracuse, NY 13057, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -76.06086979999999,
@@ -520,7 +520,7 @@
 		}
 	},
 	{
-		"address": "25737 US Rt 11, Evans Mills NY 13637",
+		"address": "25737 US-11, Evans Mills, NY 13637, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -75.8387443,
@@ -528,7 +528,7 @@
 		}
 	},
 	{
-		"address": "901 Route 110, Farmingdale NY 11735",
+		"address": "901 Broadhollow Rd, Farmingdale, NY 11735, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.42326969999999,
@@ -536,7 +536,7 @@
 		}
 	},
 	{
-		"address": "2400 Route 9, Fishkill NY 12524",
+		"address": "2400 U.S. 9, Fishkill, NY 12524, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.8971686,
@@ -544,7 +544,7 @@
 		}
 	},
 	{
-		"address": "10401 Bennett Road, Fredonia NY 14063",
+		"address": "10401 Bennett Rd, Fredonia, NY 14063, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -79.3132826,
@@ -552,7 +552,7 @@
 		}
 	},
 	{
-		"address": "1818 State Route 3, Fulton NY 13069",
+		"address": "1818 NY-3, Fulton, NY 13069, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -76.44874879999999,
@@ -560,7 +560,7 @@
 		}
 	},
 	{
-		"address": "4300 Lakeville Road, Geneseo NY 14454",
+		"address": "4300 Lakeville Rd, Geneseo, NY 14454, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -77.78629649999999,
@@ -568,7 +568,7 @@
 		}
 	},
 	{
-		"address": "990 Route 5 20, Geneva NY 14456",
+		"address": "990 NY-5, Geneva, NY 14456, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -77.02151309999999,
@@ -576,7 +576,7 @@
 		}
 	},
 	{
-		"address": "311 RT 9W, Glenmont NY 12077",
+		"address": "311 US-9W, Glenmont, NY 12077, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.79307639999999,
@@ -584,7 +584,7 @@
 		}
 	},
 	{
-		"address": "200 Dutch Meadows Ln, Glenville NY 12302",
+		"address": "200 Dutch Meadows Ln, Glenville, NY 12302, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.944432,
@@ -592,7 +592,7 @@
 		}
 	},
 	{
-		"address": "100 Elm Ridge Center Dr, Greece NY 14626",
+		"address": "100 Elmridge Center Dr, Greece, NY 14626, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -77.7242837,
@@ -600,7 +600,7 @@
 		}
 	},
 	{
-		"address": "1549 Rt 9, Halfmoon NY 12065",
+		"address": "1549 U.S. 9, Clifton Park, NY 12065, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.74796959999999,
@@ -608,7 +608,7 @@
 		}
 	},
 	{
-		"address": "5360 Southwestern Blvd, Hamburg NY 14075",
+		"address": "5360 Southwestern Blvd, Hamburg, NY 14075, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -78.8724144,
@@ -616,7 +616,7 @@
 		}
 	},
 	{
-		"address": "103 North Caroline St, Herkimer NY 13350",
+		"address": "103 N Caroline St, Herkimer, NY 13350, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -74.9937958,
@@ -624,7 +624,7 @@
 		}
 	},
 	{
-		"address": "1000 State Route 36, Hornell NY 14843",
+		"address": "1000 NY-36, Hornell, NY 14843, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -77.6698753,
@@ -632,7 +632,7 @@
 		}
 	},
 	{
-		"address": "1400 County Rd 64, Horseheads NY 14845",
+		"address": "1400 County Rd 64, Horseheads, NY 14845, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -76.8542824,
@@ -640,7 +640,7 @@
 		}
 	},
 	{
-		"address": "135 Fairgrounds Memorial Pkwy, Ithaca NY 14850",
+		"address": "135 Fairgrounds Memorial Pkwy, Ithaca, NY 14850, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -76.5138557,
@@ -648,7 +648,7 @@
 		}
 	},
 	{
-		"address": "2 Gannett Dr, Johnson City NY 13790",
+		"address": "2 Gannett Dr, Johnson City, NY 13790, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -75.9468196,
@@ -656,7 +656,7 @@
 		}
 	},
 	{
-		"address": "233 5th Ave Ext, Johnstown NY 12095",
+		"address": "233 5th Ave Ext, Gloversville, NY 12078, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -74.3222899,
@@ -664,7 +664,7 @@
 		}
 	},
 	{
-		"address": "601 Frank Stottile Blvd, Kingston NY 12401",
+		"address": "601 Frank Sottile Blvd, Kingston, NY 12401, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.98512629999999,
@@ -672,7 +672,7 @@
 		}
 	},
 	{
-		"address": "350 E Fairmount Ave, Lakewood NY 14750",
+		"address": "350 E Fairmount Ave, Lakewood, NY 14750, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -79.2999542,
@@ -680,7 +680,7 @@
 		}
 	},
 	{
-		"address": "4975 Transit Rd, Lancaster NY 14086",
+		"address": "4975 Transit Rd, Depew, NY 14043, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -78.6961476,
@@ -688,7 +688,7 @@
 		}
 	},
 	{
-		"address": "579 Troy-Schenectady Road, Latham NY 12110",
+		"address": "579 Troy Schenectady Rd, Latham, NY 12110, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.76084019999999,
@@ -696,7 +696,7 @@
 		}
 	},
 	{
-		"address": "5783 So Transit Road, Lockport NY 14094",
+		"address": "5783 S Transit Rd, Lockport, NY 14094, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -78.69358460000001,
@@ -704,7 +704,7 @@
 		}
 	},
 	{
-		"address": "7155 State Rt 12 S, Lowville NY 13367",
+		"address": "7155 NY-12, Lowville, NY 13367, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -75.4779841,
@@ -712,7 +712,7 @@
 		}
 	},
 	{
-		"address": "425 Route 31, Macedon NY 14502",
+		"address": "425 NY-31, Macedon, NY 14502, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -77.29181439999999,
@@ -720,7 +720,7 @@
 		}
 	},
 	{
-		"address": "3222 State Rt 11, Malone NY 12953",
+		"address": "3222 State Route 11, Malone, NY 12953, United States",
 		"status": "FOUND",
 		"location": {
 			"lat": -74.3292871,
@@ -728,7 +728,7 @@
 		}
 	},
 	{
-		"address": "200 Sunrise Mall, Massapequa NY 11758",
+		"address": "200 Sunrise Mall, Massapequa, NY 11758, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.4337443,
@@ -736,7 +736,7 @@
 		}
 	},
 	{
-		"address": "43 Stephenville St, Massena NY 13662",
+		"address": "43 Stephenville St, Massena, NY 13662, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -74.8778285,
@@ -744,7 +744,7 @@
 		}
 	},
 	{
-		"address": "750 Middle Country Road, Middle Island NY 11953",
+		"address": "750 Middle Country Rd, Middle Island, NY 11953, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.9469794,
@@ -752,7 +752,7 @@
 		}
 	},
 	{
-		"address": "470 Route 211 East, Middletown NY 10940",
+		"address": "470 NY-211, Middletown, NY 10940, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -74.3787239,
@@ -760,7 +760,7 @@
 		}
 	},
 	{
-		"address": "3133 E Main St, Mohegan Lake NY 10547",
+		"address": "3133 E Main St, Mohegan Lake, NY 10547, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.8667639,
@@ -768,7 +768,7 @@
 		}
 	},
 	{
-		"address": "288 Larkin, Monroe NY 10950",
+		"address": "288 Larkin Dr, Monroe, NY 10950, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -74.148402,
@@ -776,7 +776,7 @@
 		}
 	},
 	{
-		"address": "41 Anawana Lake Road, Monticello NY 12701",
+		"address": "41 Anawana Lake Rd, Monticello, NY 12701, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -74.6799298,
@@ -784,7 +784,7 @@
 		}
 	},
 	{
-		"address": "4765 Commercial Drive, New Hartford NY 13413",
+		"address": "4765 Commercial Dr, New Hartford, NY 13413, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -75.3124285,
@@ -792,7 +792,7 @@
 		}
 	},
 	{
-		"address": "1201 Rt 300, Newburgh NY 12550",
+		"address": "1201 State Rte 300, Newburgh, NY 12550, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -74.0638523,
@@ -800,7 +800,7 @@
 		}
 	},
 	{
-		"address": "255 W Main St, Avon CT 6001",
+		"address": "255 W Main St, Avon, CT 06001, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.8530026,
@@ -808,7 +808,7 @@
 		}
 	},
 	{
-		"address": "120 Commercial Parkway, Branford CT 6405",
+		"address": "120 Commercial Pkwy, Branford, CT 06405, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.8308,
@@ -816,7 +816,7 @@
 		}
 	},
 	{
-		"address": "1400 Farmington Ave, Bristol CT 6010",
+		"address": "1400 Farmington Ave, Bristol, CT 06010, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.8976785,
@@ -824,7 +824,7 @@
 		}
 	},
 	{
-		"address": "161 Berlin Road, Cromwell CT 6416",
+		"address": "161 Berlin Rd, Cromwell, CT 06416, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.7125969,
@@ -832,7 +832,7 @@
 		}
 	},
 	{
-		"address": "67 Newton Rd, Danbury CT 6810",
+		"address": "67 Newtown Rd, Danbury, CT 06810, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.41498419999999,
@@ -840,7 +840,7 @@
 		}
 	},
 	{
-		"address": "656 New Haven Ave, Derby CT 6418",
+		"address": "656 New Haven Ave, Derby, CT 06418, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.0520683,
@@ -848,7 +848,7 @@
 		}
 	},
 	{
-		"address": "69 Prospect Hill Road, East Windsor CT 6088",
+		"address": "69 Prospect Hill Rd, East Windsor, CT 06088, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.6076685,
@@ -856,7 +856,7 @@
 		}
 	},
 	{
-		"address": "150 Gold Star Hwy, Groton CT 6340",
+		"address": "150 Gold Star Hwy, Groton, CT 06340, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.0651487,
@@ -864,7 +864,7 @@
 		}
 	},
 	{
-		"address": "900 Boston Post Road, Guilford CT 6437",
+		"address": "900 Boston Post Rd, Guilford, CT 06437, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.67856069999999,
@@ -872,7 +872,7 @@
 		}
 	},
 	{
-		"address": "2300 Dixwell Ave, Hamden CT 6514",
+		"address": "2300 Dixwell Ave, Hamden, CT 06514, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.91843349999999,
@@ -880,7 +880,7 @@
 		}
 	},
 	{
-		"address": "495 Flatbush Ave, Hartford CT 6106",
+		"address": "495 Flatbush Ave, Hartford, CT 06106, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.7135954,
@@ -888,7 +888,7 @@
 		}
 	},
 	{
-		"address": "180 River Rd, Lisbon CT 6351",
+		"address": "180 River Rd, Lisbon, CT 06351, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.9894052,
@@ -896,7 +896,7 @@
 		}
 	},
 	{
-		"address": "420 Buckland Hills Dr, Manchester CT 6040",
+		"address": "420 Buckland Hills Dr, Manchester, CT 06042, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.5384313,
@@ -904,7 +904,7 @@
 		}
 	},
 	{
-		"address": "1365 Boston Post Road, Milford CT 6460",
+		"address": "1365 Boston Post Rd, Milford, CT 06460, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.0342322,
@@ -912,7 +912,7 @@
 		}
 	},
 	{
-		"address": "1100 New Haven Road, Naugatuck CT 6770",
+		"address": "1100 New Haven Rd, Naugatuck, CT 06770, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.027761,
@@ -920,7 +920,7 @@
 		}
 	},
 	{
-		"address": "315 Foxon Blvd, New Haven CT 6513",
+		"address": "315 Foxon Blvd, New Haven, CT 06513, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.8774616,
@@ -928,7 +928,7 @@
 		}
 	},
 	{
-		"address": "164 Danbury Rd, New Milford CT 6776",
+		"address": "164 Danbury Rd, New Milford, CT 06776, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.4197938,
@@ -936,7 +936,7 @@
 		}
 	},
 	{
-		"address": "3164 Berlin Turnpike, Newington CT 6111",
+		"address": "3164 Berlin Turnpike, Newington, CT 06111, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.7209015,
@@ -944,7 +944,7 @@
 		}
 	},
 	{
-		"address": "474 Boston Post Road, North Windham CT 6256",
+		"address": "474 Boston Post Rd, North Windham, CT 06256, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.17419869999999,
@@ -952,7 +952,7 @@
 		}
 	},
 	{
-		"address": "650 Main Ave, Norwalk CT 6851",
+		"address": "650 Main Ave, Norwalk, CT 06851, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.4177914,
@@ -960,7 +960,7 @@
 		}
 	},
 	{
-		"address": "680 Connecticut Avenue, Norwalk CT 6854",
+		"address": "680 Connecticut Ave, Norwalk, CT 06854, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.449511,
@@ -968,7 +968,7 @@
 		}
 	},
 	{
-		"address": "220 Salem Turnpike, Norwich CT 6360",
+		"address": "220 Salem Turnpike, Norwich, CT 06360, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.1225613,
@@ -976,7 +976,7 @@
 		}
 	},
 	{
-		"address": "655 Boston Post Rd, Old Saybrook CT 6475",
+		"address": "655 Boston Post Rd, Old Saybrook, CT 06475, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.376543,
@@ -984,7 +984,7 @@
 		}
 	},
 	{
-		"address": "625 School Street, Putnam CT 6260",
+		"address": "625 School St, Putnam, CT 06260, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -71.8891874,
@@ -992,7 +992,7 @@
 		}
 	},
 	{
-		"address": "80 Town Line Rd, Rocky Hill CT 6067",
+		"address": "80 Town Line Rd, Rocky Hill, CT 06067, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.6568118,
@@ -1000,7 +1000,7 @@
 		}
 	},
 	{
-		"address": "465 Bridgeport Avenue, Shelton CT 6484",
+		"address": "465 Bridgeport Ave, Shelton, CT 06484, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.1130573,
@@ -1008,7 +1008,7 @@
 		}
 	},
 	{
-		"address": "235 Queen St, Southington CT 6489",
+		"address": "235 Queen St, Southington, CT 06489, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.870483,
@@ -1016,7 +1016,7 @@
 		}
 	},
 	{
-		"address": "150 Barnum Avenue Cutoff, Stratford CT 6614",
+		"address": "150 Barnum Avenue Cutoff, Stratford, CT 06614, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.1195311,
@@ -1024,7 +1024,7 @@
 		}
 	},
 	{
-		"address": "970 Torringford Street, Torrington CT 6790",
+		"address": "970 Torringford St, Torrington, CT 06790, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.0780048,
@@ -1032,7 +1032,7 @@
 		}
 	},
 	{
-		"address": "844 No Colony Road, Wallingford CT 6492",
+		"address": "844 N Colony Rd, Wallingford, CT 06492, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.8114061,
@@ -1040,7 +1040,7 @@
 		}
 	},
 	{
-		"address": "910 Wolcott St, Waterbury CT 6705",
+		"address": "910 Wolcott St, Waterbury, CT 06705, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -73.0078961,
@@ -1048,7 +1048,7 @@
 		}
 	},
 	{
-		"address": "155 Waterford Parkway No, Waterford CT 6385",
+		"address": "155 Parkway N, Waterford, CT 06385, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.160697,
@@ -1056,7 +1056,7 @@
 		}
 	},
 	{
-		"address": "515 Sawmill Road, West Haven CT 6516",
+		"address": "515 Saw Mill Rd, West Haven, CT 06516, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -72.97782029999999,
@@ -1064,7 +1064,7 @@
 		}
 	},
 	{
-		"address": "2473 Hackworth Road, Adamsville AL 35005",
+		"address": "2473 Pershing Rd, Birmingham, AL 35214, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.92431649999999,
@@ -1072,7 +1072,7 @@
 		}
 	},
 	{
-		"address": "630 Coonial Promenade Pkwy, Alabaster AL 35007",
+		"address": "630 Colonial Promenade Pkwy, Alabaster, AL 35007, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.80300079999999,
@@ -1080,7 +1080,7 @@
 		}
 	},
 	{
-		"address": "2643 Hwy 280 West, Alexander City AL 35010",
+		"address": "2643 US-280, Alexander City, AL 35010, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.97202229999999,
@@ -1088,7 +1088,7 @@
 		}
 	},
 	{
-		"address": "540 West Bypass, Andalusia AL 36420",
+		"address": "540 Western Bypass, Andalusia, AL 36420, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.501071,
@@ -1096,7 +1096,7 @@
 		}
 	},
 	{
-		"address": "5560 Mcclellan Blvd, Anniston AL 36206",
+		"address": "5560 McClellan Blvd, Anniston, AL 36206, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.8201445,
@@ -1104,7 +1104,7 @@
 		}
 	},
 	{
-		"address": "1450 No Brindlee Mtn Pkwy, Arab AL 35016",
+		"address": "1450 N Brindlee Mountain Pkwy, Arab, AL 35016, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.49997049999999,
@@ -1112,7 +1112,7 @@
 		}
 	},
 	{
-		"address": "1011 US Hwy 72 East, Athens AL 35611",
+		"address": "1011 US Hwy 72 E, Athens, AL 35611, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.9587885,
@@ -1120,7 +1120,7 @@
 		}
 	},
 	{
-		"address": "973 Gilbert Ferry Road Se, Attalla AL 35954",
+		"address": "973 Gilbert Ferry Rd SE, Attalla, AL 35954, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.0934102,
@@ -1128,7 +1128,7 @@
 		}
 	},
 	{
-		"address": "1717 South College Street, Auburn AL 36830",
+		"address": "1717 S College St, Auburn, AL 36832, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.4968099,
@@ -1136,7 +1136,7 @@
 		}
 	},
 	{
-		"address": "701 Mcmeans Ave, Bay Minette AL 36507",
+		"address": "701 McMeans Ave, Bay Minette, AL 36507, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.79016089999999,
@@ -1144,7 +1144,7 @@
 		}
 	},
 	{
-		"address": "750 Academy Drive, Bessemer AL 35022",
+		"address": "750 Academy Dr, Bessemer, AL 35022, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.0021281,
@@ -1152,7 +1152,7 @@
 		}
 	},
 	{
-		"address": "312 Palisades Blvd, Birmingham AL 35209",
+		"address": "312 Palisades Blvd, Birmingham, AL 35209, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.821604,
@@ -1160,7 +1160,7 @@
 		}
 	},
 	{
-		"address": "1600 Montclair Rd, Birmingham AL 35210",
+		"address": "1600 Montclair Rd, Birmingham, AL 35210, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.7200743,
@@ -1168,7 +1168,7 @@
 		}
 	},
 	{
-		"address": "5919 Trussville Crossings Pkwy, Birmingham AL 35235",
+		"address": "5919 Trussville Crossings Pkwy, Birmingham, AL 35235, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.6291251,
@@ -1176,7 +1176,7 @@
 		}
 	},
 	{
-		"address": "9248 Parkway East, Birmingham AL 35206",
+		"address": "9248 Parkway E, Birmingham, AL 35206, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.7004457,
@@ -1184,7 +1184,7 @@
 		}
 	},
 	{
-		"address": "1972 Hwy 431, Boaz AL 35957",
+		"address": "1972 US-431, Boaz, AL 35957, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.1532368,
@@ -1192,7 +1192,7 @@
 		}
 	},
 	{
-		"address": "10675 Hwy 5, Brent AL 35034",
+		"address": "10675 AL-5, Brent, AL 35034, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.1720479,
@@ -1200,7 +1200,7 @@
 		}
 	},
 	{
-		"address": "2041 Douglas Avenue, Brewton AL 36426",
+		"address": "2041 Douglas Ave, Brewton, AL 36426, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.0698326,
@@ -1208,7 +1208,7 @@
 		}
 	},
 	{
-		"address": "5100 Hwy 31, Calera AL 35040",
+		"address": "5100 US-31, Calera, AL 35040, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.7491337,
@@ -1216,7 +1216,7 @@
 		}
 	},
 	{
-		"address": "1916 Center Point Rd, Center Point AL 35215",
+		"address": "1916 Center Point Pkwy, Birmingham, AL 35215, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.6844833,
@@ -1224,7 +1224,7 @@
 		}
 	},
 	{
-		"address": "1950 W Main St, Centre AL 35960",
+		"address": "1950 W Main St, Centre, AL 35960, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.7126492,
@@ -1232,7 +1232,7 @@
 		}
 	},
 	{
-		"address": "16077 Highway 280, Chelsea AL 35043",
+		"address": "16077 US-280, Chelsea, AL 35043, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.6190613,
@@ -1240,7 +1240,7 @@
 		}
 	},
 	{
-		"address": "1415 7Th Street South, Clanton AL 35045",
+		"address": "1415 7th St S, Clanton, AL 35045, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.6092924,
@@ -1248,7 +1248,7 @@
 		}
 	},
 	{
-		"address": "626 Olive Street Sw, Cullman AL 35055",
+		"address": "626 Olive St SW, Cullman, AL 35055, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.8417989,
@@ -1256,7 +1256,7 @@
 		}
 	},
 	{
-		"address": "27520 Hwy 98, Daphne AL 36526",
+		"address": "27520 US-98, Daphne, AL 36526, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.90436369999999,
@@ -1264,7 +1264,7 @@
 		}
 	},
 	{
-		"address": "2800 Spring Avn SW, Decatur AL 35603",
+		"address": "2800 Spring Ave SW, Decatur, AL 35603, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.9958752,
@@ -1272,7 +1272,7 @@
 		}
 	},
 	{
-		"address": "969 Us Hwy 80 West, Demopolis AL 36732",
+		"address": "969 US-80, Demopolis, AL 36732, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.8343616,
@@ -1280,7 +1280,7 @@
 		}
 	},
 	{
-		"address": "3300 South Oates Street, Dothan AL 36301",
+		"address": "3300 S Oates St, Dothan, AL 36301, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.4044898,
@@ -1288,7 +1288,7 @@
 		}
 	},
 	{
-		"address": "4310 Montgomery Hwy, Dothan AL 36303",
+		"address": "4310 Montgomery Hwy, Dothan, AL 36303, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.44126469999999,
@@ -1296,7 +1296,7 @@
 		}
 	},
 	{
-		"address": "600 Boll Weevil Circle, Enterprise AL 36330",
+		"address": "600 Boll Weevil Cir, Enterprise, AL 36330, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.82742909999999,
@@ -1304,7 +1304,7 @@
 		}
 	},
 	{
-		"address": "3176 South Eufaula Avenue, Eufaula AL 36027",
+		"address": "3176 S Eufaula Ave, Eufaula, AL 36027, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.17106129999999,
@@ -1312,7 +1312,7 @@
 		}
 	},
 	{
-		"address": "7100 Aaron Aronov Drive, Fairfield AL 35064",
+		"address": "7100 Aaron Aronov Dr, Fairfield, AL 35064, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.91817429999999,
@@ -1320,7 +1320,7 @@
 		}
 	},
 	{
-		"address": "10040 County Road 48, Fairhope AL 36533",
+		"address": "10040 Co Rd 48, Fairhope, AL 36532, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.85171380000001,
@@ -1328,7 +1328,7 @@
 		}
 	},
 	{
-		"address": "3186 Hwy 171 North, Fayette AL 35555",
+		"address": "3186 AL-171, Fayette, AL 35555, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.8102894,
@@ -1336,7 +1336,7 @@
 		}
 	},
 	{
-		"address": "3100 Hough Rd, Florence AL 35630",
+		"address": "3100 Hough Rd, Florence, AL 35630, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.6251166,
@@ -1344,7 +1344,7 @@
 		}
 	},
 	{
-		"address": "2200 South Mckenzie St, Foley AL 36535",
+		"address": "2200 S McKenzie St, Foley, AL 36535, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.6863106,
@@ -1352,7 +1352,7 @@
 		}
 	},
 	{
-		"address": "2001 Glenn Bldv Sw, Fort Payne AL 35968",
+		"address": "2001 Glenn Blvd SW, Fort Payne, AL 35968, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.7620185,
@@ -1360,7 +1360,7 @@
 		}
 	},
 	{
-		"address": "340 East Meighan Blvd, Gadsden AL 35903",
+		"address": "340 E Meighan Blvd, Gadsden, AL 35903, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.9872204,
@@ -1368,7 +1368,7 @@
 		}
 	},
 	{
-		"address": "890 Odum Road, Gardendale AL 35071",
+		"address": "890 Odum Rd, Gardendale, AL 35071, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.8229535,
@@ -1376,7 +1376,7 @@
 		}
 	},
 	{
-		"address": "1608 W Magnolia Ave, Geneva AL 36340",
+		"address": "1608 W Magnolia Ave, Geneva, AL 36340, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.8993835,
@@ -1384,7 +1384,7 @@
 		}
 	},
 	{
-		"address": "501 Willow Lane, Greenville AL 36037",
+		"address": "501 Willow Ln, Greenville, AL 36037, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.6472088,
@@ -1392,7 +1392,7 @@
 		}
 	},
 	{
-		"address": "170 Fort Morgan Road, Gulf Shores AL 36542",
+		"address": "170 Fort Morgan Road, Gulf Shores, AL 36542, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -88.00811399999999,
@@ -1400,7 +1400,7 @@
 		}
 	},
 	{
-		"address": "11697 US Hwy 431, Guntersville AL 35976",
+		"address": "11697 US-431, Guntersville, AL 35976, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.2843999,
@@ -1408,7 +1408,7 @@
 		}
 	},
 	{
-		"address": "42417 Hwy 195, Haleyville AL 35565",
+		"address": "42417 AL-195, Haleyville, AL 35565, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.5975757,
@@ -1416,7 +1416,7 @@
 		}
 	},
 	{
-		"address": "1706 Military Street South, Hamilton AL 35570",
+		"address": "1706 Military St S, Hamilton, AL 35570, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.9924214,
@@ -1424,7 +1424,7 @@
 		}
 	},
 	{
-		"address": "1201 Hwy 31 NW, Hartselle AL 35640",
+		"address": "1201 US-31, Hartselle, AL 35640, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.94883,
@@ -1432,7 +1432,7 @@
 		}
 	},
 	{
-		"address": "209 Lakeshore Parkway, Homewood AL 35209",
+		"address": "209 Lakeshore Pkwy, Homewood, AL 35209, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.82104,
@@ -1440,7 +1440,7 @@
 		}
 	},
 	{
-		"address": "2780 John Hawkins Pkwy, Hoover AL 35244",
+		"address": "2780 John Hawkins Pkwy, Hoover, AL 35244, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.8248581,
@@ -1448,7 +1448,7 @@
 		}
 	},
 	{
-		"address": "5335 Hwy 280 South, Hoover AL 35242",
+		"address": "5335 US-280, Birmingham, AL 35242, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.67610499999999,
@@ -1456,7 +1456,7 @@
 		}
 	},
 	{
-		"address": "1007 Red Farmer Drive, Hueytown AL 35023",
+		"address": "1007 Red Farmer Dr, Hueytown, AL 35023, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.968353,
@@ -1464,7 +1464,7 @@
 		}
 	},
 	{
-		"address": "2900 S Mem PkwyDrake Ave, Huntsville AL 35801",
+		"address": "2900 S. Mem Pkwy(Drake Ave), Huntsville, Al 35801, Huntsville, AL 35801, United States",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.5831398,
@@ -1472,7 +1472,7 @@
 		}
 	},
 	{
-		"address": "11610 Memorial Pkwy South, Huntsville AL 35803",
+		"address": "11610 Memorial Pkwy SW, Huntsville, AL 35803, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.5705906,
@@ -1480,7 +1480,7 @@
 		}
 	},
 	{
-		"address": "2200 Sparkman Drive, Huntsville AL 35810",
+		"address": "2200 Sparkman Dr NW, Huntsville, AL 35810, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.5923076,
@@ -1488,7 +1488,7 @@
 		}
 	},
 	{
-		"address": "330 Sutton Rd, Huntsville AL 35763",
+		"address": "330 Sutton Rd, Owens Cross Roads, AL 35763, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.48825099999999,
@@ -1496,7 +1496,7 @@
 		}
 	},
 	{
-		"address": "6140A Univ Drive, Huntsville AL 35806",
+		"address": "6140 University Dr, Huntsville, AL 35806, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.67584959999999,
@@ -1504,7 +1504,7 @@
 		}
 	},
 	{
-		"address": "4206 N College Ave, Jackson AL 36545",
+		"address": "4206 N College Ave, Jackson, AL 36545, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.8756883,
@@ -1512,7 +1512,7 @@
 		}
 	},
 	{
-		"address": "1625 Pelham South, Jacksonville AL 36265",
+		"address": "1625 Pelham Rd S, Jacksonville, AL 36265, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.7620786,
@@ -1520,7 +1520,7 @@
 		}
 	},
 	{
-		"address": "1801 Hwy 78 East, Jasper AL 35501",
+		"address": "1801 Hwy 78 E, Jasper, AL 35501, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.25442079999999,
@@ -1528,7 +1528,7 @@
 		}
 	},
 	{
-		"address": "8551 Whitfield Ave, Leeds AL 35094",
+		"address": "8551 Whitfield Ave, Leeds, AL 35094, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.5189736,
@@ -1536,7 +1536,7 @@
 		}
 	},
 	{
-		"address": "8650 Madison Blvd, Madison AL 35758",
+		"address": "8650 Madison Blvd, Madison, AL 35758, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.74116590000001,
@@ -1544,7 +1544,7 @@
 		}
 	},
 	{
-		"address": "145 Kelley Blvd, Millbrook AL 36054",
+		"address": "145 Kelley Blvd, Millbrook, AL 36054, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.39816290000002,
@@ -1552,7 +1552,7 @@
 		}
 	},
 	{
-		"address": "1970 S University Blvd, Mobile AL 36609",
+		"address": "1970 S University Blvd, Mobile, AL 36609, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -88.1623489,
@@ -1560,7 +1560,7 @@
 		}
 	},
 	{
-		"address": "6350 Cottage Hill Road, Mobile AL 36609",
+		"address": "6350 Cottage Hill Rd, Mobile, AL 36609, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -88.18923470000001,
@@ -1568,7 +1568,7 @@
 		}
 	},
 	{
-		"address": "101 South Beltline Highway, Mobile AL 36606",
+		"address": "101 S Beltline Hwy, Mobile, AL 36608, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -88.12735599999999,
@@ -1576,7 +1576,7 @@
 		}
 	},
 	{
-		"address": "2500 Dawes Road, Mobile AL 36695",
+		"address": "2500 Dawes Rd, Mobile, AL 36695, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -88.2463898,
@@ -1584,7 +1584,7 @@
 		}
 	},
 	{
-		"address": "5245 Rangeline Service Rd, Mobile AL 36619",
+		"address": "5245 Rangeline Service Rd, Mobile, AL 36619, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -88.1628328,
@@ -1592,7 +1592,7 @@
 		}
 	},
 	{
-		"address": "685 Schillinger Rd, Mobile AL 36695",
+		"address": "685 Schillinger Rd, Mobile, AL 36695, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -88.2244297,
@@ -1600,7 +1600,7 @@
 		}
 	},
 	{
-		"address": "3371 S Alabama Ave, Monroeville AL 36460",
+		"address": "3371 S Alabama Ave, Monroeville, AL 36460, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.3282674,
@@ -1608,7 +1608,7 @@
 		}
 	},
 	{
-		"address": "10710 Chantilly Pkwy, Montgomery AL 36117",
+		"address": "10710 Chantilly Pkwy, Montgomery, AL 36117, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.13494949999999,
@@ -1616,7 +1616,7 @@
 		}
 	},
 	{
-		"address": "3801 Eastern Blvd, Montgomery AL 36116",
+		"address": "3801 Eastern Blvd, Montgomery, AL 36116, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.23204659999999,
@@ -1624,7 +1624,7 @@
 		}
 	},
 	{
-		"address": "6495 Atlanta Hwy, Montgomery AL 36117",
+		"address": "6495 Atlanta Hwy, Montgomery, AL 36117, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.1851159,
@@ -1632,7 +1632,7 @@
 		}
 	},
 	{
-		"address": "851 Ann St, Montgomery AL 36107",
+		"address": "851 Ann St, Montgomery, AL 36107, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.26823279999999,
@@ -1640,7 +1640,7 @@
 		}
 	},
 	{
-		"address": "15445 Highway 24, Moulton AL 35650",
+		"address": "15445 AL-24, Moulton, AL 35650, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.2769098,
@@ -1648,7 +1648,7 @@
 		}
 	},
 	{
-		"address": "517 West Avalon Ave, Muscle Shoals AL 35661",
+		"address": "517 W Avalon Ave, Muscle Shoals, AL 35661, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.6680631,
@@ -1656,7 +1656,7 @@
 		}
 	},
 	{
-		"address": "5710 Mcfarland Blvd, Northport AL 35476",
+		"address": "5710 McFarland Blvd, Northport, AL 35476, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.6152439,
@@ -1664,7 +1664,7 @@
 		}
 	},
 	{
-		"address": "2453 2Nd Avenue East, Oneonta AL 35121  205-625-647",
+		"address": "2453 2nd Ave E, Oneonta, AL 35121, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.4497804,
@@ -1672,7 +1672,7 @@
 		}
 	},
 	{
-		"address": "2900 Pepperrell Pkwy, Opelika AL 36801",
+		"address": "2900 Pepperell Pkwy, Opelika, AL 36801, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.42191969999999,
@@ -1680,7 +1680,7 @@
 		}
 	},
 	{
-		"address": "92 Plaza Lane, Oxford AL 36203",
+		"address": "92 Plaza Ln, Oxford, AL 36203, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.832306,
@@ -1688,7 +1688,7 @@
 		}
 	},
 	{
-		"address": "1537 Hwy 231 South, Ozark AL 36360",
+		"address": "1537 US-231, Ozark, AL 36360, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.6507123,
@@ -1696,7 +1696,7 @@
 		}
 	},
 	{
-		"address": "2181 Pelham Pkwy, Pelham AL 35124",
+		"address": "2181 Pelham Pkwy, Pelham, AL 35124, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.7910991,
@@ -1704,7 +1704,7 @@
 		}
 	},
 	{
-		"address": "165 Vaughan Ln, Pell City AL 35125",
+		"address": "165 Vaughan Ln, Pell City, AL 35125, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.2771167,
@@ -1712,7 +1712,7 @@
 		}
 	},
 	{
-		"address": "3700 Hwy 280-431 N, Phenix City AL 36867",
+		"address": "3700 US-280, Phenix City, AL 36867, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.04146639999999,
@@ -1720,7 +1720,7 @@
 		}
 	},
 	{
-		"address": "1903 Cobbs Ford Rd, Prattville AL 36066",
+		"address": "1903 Cobbs Ford Rd, Prattville, AL 36066, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.416358,
@@ -1728,7 +1728,7 @@
 		}
 	},
 	{
-		"address": "4180 Us Hwy 431, Roanoke AL 36274",
+		"address": "4180 US-431, Roanoke, AL 36274, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.36604779999999,
@@ -1736,7 +1736,7 @@
 		}
 	},
 	{
-		"address": "13675 Hwy 43, Russellville AL 35653",
+		"address": "13675 US-43, Russellville, AL 35653, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.7270578,
@@ -1744,7 +1744,7 @@
 		}
 	},
 	{
-		"address": "1095 Industrial Pkwy, Saraland AL 36571",
+		"address": "1095 Industrial Pkwy, Saraland, AL 36571, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -88.0969451,
@@ -1752,7 +1752,7 @@
 		}
 	},
 	{
-		"address": "24833 Johnt Reidprkw, Scottsboro AL 35768",
+		"address": "24833 John T Reid Pkwy, Scottsboro, AL 35768, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.0082257,
@@ -1760,7 +1760,7 @@
 		}
 	},
 	{
-		"address": "1501 Hwy 14 East, Selma AL 36703",
+		"address": "1501 AL-14, Selma, AL 36703, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.0128512,
@@ -1768,7 +1768,7 @@
 		}
 	},
 	{
-		"address": "7855 Moffett Rd, Semmes AL 36575",
+		"address": "7855 Moffett Rd, Semmes, AL 36575, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -88.2295457,
@@ -1776,7 +1776,7 @@
 		}
 	},
 	{
-		"address": "150 Springville Station Blvd, Springville AL 35146",
+		"address": "150 Springville Station, Springville, AL 35146, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.4328843,
@@ -1784,7 +1784,7 @@
 		}
 	},
 	{
-		"address": "690 Hwy 78, Sumiton AL 35148",
+		"address": "690 Hwy 78, Sumiton, AL 35148, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.0417709,
@@ -1792,7 +1792,7 @@
 		}
 	},
 	{
-		"address": "41301 US Hwy 280, Sylacauga AL 35150",
+		"address": "41301 US-280, Sylacauga, AL 35150, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.2854302,
@@ -1800,7 +1800,7 @@
 		}
 	},
 	{
-		"address": "214 Haynes Street, Talladega AL 35160",
+		"address": "214 Haynes St, Talladega, AL 35160, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.08019759999999,
@@ -1808,7 +1808,7 @@
 		}
 	},
 	{
-		"address": "1300 Gilmer Ave, Tallassee AL 36078",
+		"address": "1300 Gilmer Ave, Tallassee, AL 36078, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.9170779,
@@ -1816,7 +1816,7 @@
 		}
 	},
 	{
-		"address": "34301 Hwy 43, Thomasville AL 36784",
+		"address": "34301 US-43, Thomasville, AL 36784, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.73957639999999,
@@ -1824,7 +1824,7 @@
 		}
 	},
 	{
-		"address": "1420 Us 231 South, Troy AL 36081",
+		"address": "1420 US-231, Troy, AL 36081, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.93907779999999,
@@ -1832,7 +1832,7 @@
 		}
 	},
 	{
-		"address": "1501 Skyland Blvd E, Tuscaloosa AL 35405",
+		"address": "1501 Skyland Blvd E, Tuscaloosa, AL 35405, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.5187189,
@@ -1840,7 +1840,7 @@
 		}
 	},
 	{
-		"address": "3501 20th Av, Valley AL 36854",
+		"address": "3501 20th Ave, Valley, AL 36854, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -85.1788784,
@@ -1848,7 +1848,7 @@
 		}
 	},
 	{
-		"address": "1300 Montgomery Highway, Vestavia Hills AL 35216",
+		"address": "1300 Montgomery Hwy, Vestavia Hills, AL 35216, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.7918224,
@@ -1856,7 +1856,7 @@
 		}
 	},
 	{
-		"address": "4538 Us Hwy 231, Wetumpka AL 36092",
+		"address": "4538 US-231, Wetumpka, AL 36092, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -86.2123159,
@@ -1864,7 +1864,7 @@
 		}
 	},
 	{
-		"address": "2575 Us Hwy 43, Winfield AL 35594",
+		"address": "2575 US-43, Winfield, AL 35594, USA",
 		"status": "FOUND",
 		"location": {
 			"lat": -87.84070109999999,

--- a/src/main/java/org/cjwilson/geoaddress/GeoAddressLocationBuilder.java
+++ b/src/main/java/org/cjwilson/geoaddress/GeoAddressLocationBuilder.java
@@ -1,0 +1,83 @@
+package org.cjwilson.geoaddress;
+
+import javax.json.JsonObject;
+
+public class GeoAddressLocationBuilder {
+
+
+  private final JsonObject geoCodeLocation;
+  private final JsonObject locationObj;
+  private final String geoCodeStatus;
+  private final String formattedAddress;
+  private String address;
+  private String status;
+
+
+  public GeoAddressLocationBuilder(final JsonObject geoCodeLocation) {
+    this.geoCodeLocation = geoCodeLocation;
+    this.geoCodeStatus = this.geoCodeLocation.getString("status");
+    this.locationObj = geoCodeStatus.equals("OK")
+        ? geoCodeLocation.get("results").asJsonArray().get(0).asJsonObject().get("geometry")
+            .asJsonObject().get("location").asJsonObject()
+        : null;
+    this.formattedAddress = geoCodeStatus.equals("OK") ? geoCodeLocation.get("results")
+        .asJsonArray().get(0).asJsonObject().getString("formatted_address") : null;
+  }
+
+  public static GeoAddressLocationBuilder newBuilder(final JsonObject geoCodeLocation) {
+    return new GeoAddressLocationBuilder(geoCodeLocation);
+  }
+
+  public GeoAddressLocationBuilder withStatus(final String status) {
+    this.status = status;
+    return this;
+  }
+
+  public GeoAddressLocationBuilder withAddress(final String address) {
+    this.address = address;
+    return this;
+  }
+
+  public GeoAddressLocation build() {
+    if (this.formattedAddress == null && this.address == null) {
+      throw new IllegalStateException("Addresses cannot be null");
+    }
+    return new GeoAddressLocation() {
+
+      @Override
+      public JsonObject locationJsonObj() {
+        return this.locationJsonObj();
+      }
+
+      @Override
+      public String status() {
+        if (status != null) {
+          return status;
+        }
+        if (geoCodeStatus.equals("OK")) {
+          return "FOUND";
+        } else if (geoCodeStatus.equals("OVER_QUERY_LIMIT")
+            || geoCodeStatus.equals("UNKNOWN_ERROR")) {
+          return geoCodeStatus;
+        }
+        return "NOT_FOUND";
+      }
+
+      @Override
+      public Double lng() {
+        return locationObj != null ? locationObj.getJsonNumber("lat").doubleValue() : 0d;
+      }
+
+      @Override
+      public Double lat() {
+        return locationObj != null ? locationObj.getJsonNumber("lng").doubleValue() : 0d;
+      }
+
+      @Override
+      public String address() {
+        return address != null ? address : formattedAddress;
+      }
+    };
+  }
+
+}


### PR DESCRIPTION
Adds a builder for the GeoAddressLocation with cleans up the code considerably by abstracting the logic for resolving the results logic into a concrete object. The `formattedAddress` returned from the service was also included as it will add leading zeros to zip and country of origin.. sweet! 